### PR TITLE
Feature/kernel updates

### DIFF
--- a/99-ach.rules
+++ b/99-ach.rules
@@ -1,0 +1,10 @@
+# Control permissions for ach character devices
+
+# Set the permissions of the ach control device
+KERNEL=="achctrl", GROUP="ach", MODE="660"
+
+# Set the permissions of ach channel devices
+KERNEL=="ach-*", GROUP="ach", MODE="660"
+
+# Create symbolic links for ach channel devices
+KERNEL=="ach-*", SYMLINK+="ach/%k"

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@ BUILT_SOURCES =
 EXTRA_DIST = \
 	spin
 
-AM_DISTCHECK_CONFIGURE_FLAGS=--enable-dkms --disable-dkms-build --disable-kbuild --with-python --with-java
+AM_DISTCHECK_CONFIGURE_FLAGS=--disable-dkms --disable-dkms-build --disable-kbuild --with-python
 
 # dist_bin_SCRIPTS = achpipe achlog
 
@@ -390,6 +390,7 @@ dkms_DATA = src/klinux/dkms/dkms.conf src/klinux/ach_klinux.c src/klinux/dkms/Kb
 
 udevdir=/etc/udev/rules.d/
 udev_DATA=99-ach.rules
+EXTRA_DIST +=99-ach.rules
 endif
 
 ###########

--- a/Makefile.am
+++ b/Makefile.am
@@ -388,6 +388,8 @@ dkmspkginclude_HEADERS = \
 	 include/ach/private_klinux.h
 dkms_DATA = src/klinux/dkms/dkms.conf src/klinux/ach_klinux.c src/klinux/dkms/Kbuild
 
+udevdir=/etc/udev/rules.d/
+udev_DATA=99-ach.rules
 endif
 
 ###########

--- a/configure.ac
+++ b/configure.ac
@@ -471,7 +471,7 @@ AS_IF([test "x$enable_dkms" = xyes],
       [AC_MSG_CHECKING([whether ach group exists])
        AS_IF([test ! $(getent group ach) ],
              [AC_MSG_RESULT([no]) 
-              AC_MSG_ERROR([kernel module requires an 'ach' group, but none was found.])],
+              AC_MSG_ERROR([kernel module requires an 'ach' group, but none was found. Please create the 'ach' group and add any users to it that should use 'ach'])],
              [AC_MSG_RESULT(yes)])])
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -467,6 +467,12 @@ AM_CONDITIONAL([INSTALL_DKMS],
 AM_CONDITIONAL([BUILD_DKMS],
                [test "x$enable_dkms_build" = xyes])
 
+AS_IF([test "x$enable_dkms" = xyes],
+      [AC_MSG_CHECKING([whether ach group exists])
+       AS_IF([test ! $(getent group ach) ],
+             [AC_MSG_RESULT([no]) 
+              AC_MSG_ERROR([kernel module requires an 'ach' group, but none was found.])],
+             [AC_MSG_RESULT(yes)])])
 
 
 #########

--- a/doc/ach-klinux.rules
+++ b/doc/ach-klinux.rules
@@ -1,10 +1,10 @@
 # Example udev rules for Ach Linux Kernel Module
 
 # Set the permissions of the ach control device
-KERNEL=="achctrl", GROUP=="ach", MODE=="660"
+KERNEL=="achctrl", GROUP="ach", MODE=="660"
 
 # Set the permissions of ach channel devices
-KERNEL=="ach-*", GROUP=="ach", MODE=="660"
+KERNEL=="ach-*", GROUP="ach", MODE=="660"
 
 # Create symbolic links for ach channel devices
 KERNEL=="ach-*", SYMLINK+="ach/%k"

--- a/doc/ach-manual.xml
+++ b/doc/ach-manual.xml
@@ -890,10 +890,10 @@ ach rm my-channel
 # Control permissions for ach character devices
 
 # Set the permissions of the ach control device
-KERNEL=="achctrl", GROUP=="ach", MODE=="660"
+KERNEL=="achctrl", GROUP="ach", MODE="660"
 
 # Set the permissions of ach channel devices
-KERNEL=="ach-*", GROUP=="ach", MODE=="660"
+KERNEL=="ach-*", GROUP="ach", MODE="660"
 
 # Create symbolic links for ach channel devices
 KERNEL=="ach-*", SYMLINK+="ach/%k"

--- a/include/ach/generic.h
+++ b/include/ach/generic.h
@@ -268,7 +268,11 @@ ach_put_fun(void *cx, void *chan_dst, const void *obj_src);
  *  updating when no changes exist. */
 typedef struct achk_opt {
     int options;               /**< get options used by the kernel */
+    #ifdef __KERNEL__
+    struct timespec64 reltime;
+    #else
     struct timespec reltime;   /**< kernel use relative time */
+    #endif
 } achk_opt_t;
 
 #ifdef CONFIG_COMPAT
@@ -276,7 +280,11 @@ typedef struct achk_opt {
 /** Compat struct for achk_opt */
 typedef struct achk_opt_32 {
     int options;                      /**< get options used by the kernel */
-    struct compat_timespec reltime;   /**< kernel use relative time */
+    #ifdef __KERNEL__
+    struct old_timespec32 reltime;   /**< kernel use relative time */
+    #else
+    struct compat_timespec reltime;
+    #endif
 } achk_opt_t_32;
 
 #endif /* CONFIG_COMPAT */

--- a/include/ach/impl_generic.h
+++ b/include/ach/impl_generic.h
@@ -60,11 +60,11 @@
 
 /** Lock the channel for reading.
  *
- * \param[in] timeout In user-mode this is an absolute timeout.  In
- *                    kernel mode, it is a relative timeout.
+ * \param[in] timeout In user-mode this is an absolute timeout given as a const struct timespec*.  In
+ *                    kernel mode, it is a relative timeout given as a const struct timespec64*.
  */
 static enum ach_status ACH_WARN_UNUSED
-rdlock( ach_channel_t *chan, int wait, const struct timespec *timeout );
+rdlock( ach_channel_t *chan, int wait, const void* timeout );
 
 /** Lock the channel for writing */
 static enum ach_status ACH_WARN_UNUSED
@@ -248,7 +248,7 @@ ach_xget_from_offset(ach_channel_t * chan, size_t index_offset,
 static enum ach_status ACH_WARN_UNUSED
 ach_xget(ach_channel_t * chan, ach_get_fun transfer, void *cx, void **pobj,
          size_t * frame_size,
-         const struct timespec *timeout,
+         const void *timeout,
          int options )
 {
     struct ach_header *shm = chan->shm;

--- a/src/klinux/ach_klinux.c
+++ b/src/klinux/ach_klinux.c
@@ -480,8 +480,6 @@ static int ach_ch_close(struct inode *inode, struct file *file)
 	struct ach_ch_file *ch_file;
 	int ret = 0;
 
-	KDEBUG("ach: in ach_ch_close (inode %d)\n", iminor(inode));
-
 	/* Synchronize to protect refcounting */
 	if (rt_mutex_lock_interruptible(&ctrl_data.lock)) {
 		ret = -ERESTARTSYS;
@@ -539,12 +537,9 @@ static long ach_ch_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 	int ret = 0;
 	struct ach_ch_file *ch_file = (struct ach_ch_file *)file->private_data;
 
-	KDEBUG("ach: In ach_ch_ioctl\n");
-
 	switch (cmd) {
 
 	case ACH_CH_SET_MODE: {
-		KDEBUG("ach: Got ACH_CH_SET_MODE\n");
 		struct achk_opt opt;
 		if (copy_from_user(&opt, (void*)arg, sizeof(opt)) ) {
                        ret = -EFAULT;
@@ -556,7 +551,6 @@ static long ach_ch_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 		break;
 	}
 	case ACH_CH_GET_MODE:{
-			KDEBUG("ach: Got cmd ACH_CH_GET_MODE: %ld\n", arg);
 			if( copy_to_user((void*)arg, &ch_file->mode, sizeof(ch_file->mode)) )
 				ret = -EFAULT;
 			else
@@ -564,7 +558,6 @@ static long ach_ch_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 			break;
 		}
 	case ACH_CH_GET_STATUS:{
-			KDEBUG("ach: Got cmd ACH_CH_GET_STATUS\n");
 			if (rt_mutex_lock_interruptible(&ch_file->shm->sync.mutex)) {
 				ret = -ERESTARTSYS;
 				break;
@@ -613,17 +606,14 @@ static long ach_ch_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 			break;
 		}
 	case ACH_CH_FLUSH:
-		KDEBUG("ach: Got cmd ACH_CH_FLUSH\n");
 		ret = -get_errno( ach_flush(ch_file) );
 		break;
 	case ACH_CH_CANCEL:{
 			unsigned int unsafe = (unsigned int)arg;
-			KDEBUG("ach: Got cmd ACH_CH_CANCEL\n");
 			ret = -get_errno(ach_cancel(ch_file, unsafe));
 			break;
 		}
 	case ACH_CH_GET_OPTIONS: {
-		KDEBUG("ach: Got ACH_CH_GET_OPTIONS\n");
 		struct ach_ch_options retval;
 		retval.mode = ch_file->mode;
 		retval.clock = ch_file->shm->clock;
@@ -890,7 +880,6 @@ ctrl_create (struct ach_ctrl_create_ch *arg )
 static long ach_ctrl_ioctl(struct file *file, unsigned int cmd,
 			   unsigned long arg)
 {
-	KDEBUG("ach: in ach_ctrl_ioctl");
 	/* TODO: Validate argument */
 	int ret = 0;
 
@@ -902,7 +891,6 @@ static long ach_ctrl_ioctl(struct file *file, unsigned int cmd,
 
 	case ACH_CTRL_CREATE_CH: {
 		struct ach_ctrl_create_ch create_arg;
-		KDEBUG("ach: Control command create\n");
 		if (copy_from_user(&create_arg, (void*)arg, sizeof(create_arg)) ) {
 			ret = -EFAULT;
 		} else if ( strnlen(create_arg.name,ACH_CHAN_NAME_MAX)
@@ -915,7 +903,6 @@ static long ach_ctrl_ioctl(struct file *file, unsigned int cmd,
 	}
 	case ACH_CTRL_UNLINK_CH:{
 		struct ach_ctrl_unlink_ch unlink_arg;
-		KDEBUG("ach: Control command unlink\n");
 		if (copy_from_user(&unlink_arg, (void*)arg, sizeof(unlink_arg)) ) {
 			ret = -EFAULT;
 		} else if ( strnlen(unlink_arg.name,ACH_CHAN_NAME_MAX)
@@ -1011,7 +998,7 @@ static struct file_operations ach_ctrl_fops = {
 	.llseek = NULL,
 };
 
-#define DEV_CLASS_MODE ((umode_t)(S_IRUGO|S_IWUGO))
+#define DEV_CLASS_MODE ((umode_t)(S_IRUSR | S_IRGRP))
 static struct miscdevice ach_misc_device = {
 	.minor = MISC_DYNAMIC_MINOR,
 	.name = "achctrl",

--- a/src/klinux/ach_klinux.c
+++ b/src/klinux/ach_klinux.c
@@ -480,7 +480,9 @@ static int ach_ch_close(struct inode *inode, struct file *file)
 {
 	struct ach_ch_file *ch_file;
 	int ret = 0;
-
+	
+	KDEBUG("ach: in ach_ch_close (inode %d)\n", iminor(inode));
+	
 	/* Synchronize to protect refcounting */
 	if (rt_mutex_lock_interruptible(&ctrl_data.lock)) {
 		ret = -ERESTARTSYS;
@@ -538,6 +540,8 @@ static long ach_ch_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 	int ret = 0;
 	struct ach_ch_file *ch_file = (struct ach_ch_file *)file->private_data;
 
+	KDEBUG("ach: In ach_ch_ioctl\n");
+	
 	switch (cmd) {
 
 	case ACH_CH_SET_MODE: {
@@ -552,6 +556,7 @@ static long ach_ch_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 		break;
 	}
 	case ACH_CH_GET_MODE:{
+			KDEBUG("ach: Got cmd ACH_CH_GET_MODE: %ld\n", arg);
 			if( copy_to_user((void*)arg, &ch_file->mode, sizeof(ch_file->mode)) )
 				ret = -EFAULT;
 			else
@@ -559,6 +564,7 @@ static long ach_ch_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 			break;
 		}
 	case ACH_CH_GET_STATUS:{
+			KDEBUG("ach: Got cmd ACH_CH_GET_STATUS\n");
 			if (rt_mutex_lock_interruptible(&ch_file->shm->sync.mutex)) {
 				ret = -ERESTARTSYS;
 				break;
@@ -607,10 +613,12 @@ static long ach_ch_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 			break;
 		}
 	case ACH_CH_FLUSH:
+		KDEBUG("ach: Got cmd ACH_CH_FLUSH\n");
 		ret = -get_errno( ach_flush(ch_file) );
 		break;
 	case ACH_CH_CANCEL:{
 			unsigned int unsafe = (unsigned int)arg;
+			KDEBUG("ach: Got cmd ACH_CH_CANCEL\n");
 			ret = -get_errno(ach_cancel(ch_file, unsafe));
 			break;
 		}
@@ -891,6 +899,7 @@ static long ach_ctrl_ioctl(struct file *file, unsigned int cmd,
 	switch (cmd) {
 
 	case ACH_CTRL_CREATE_CH: {
+		KDEBUG("ach: Control command create\n");
 		struct ach_ctrl_create_ch create_arg;
 		if (copy_from_user(&create_arg, (void*)arg, sizeof(create_arg)) ) {
 			ret = -EFAULT;
@@ -904,6 +913,7 @@ static long ach_ctrl_ioctl(struct file *file, unsigned int cmd,
 	}
 	case ACH_CTRL_UNLINK_CH:{
 		struct ach_ctrl_unlink_ch unlink_arg;
+		KDEBUG("ach: Control command unlink\n");
 		if (copy_from_user(&unlink_arg, (void*)arg, sizeof(unlink_arg)) ) {
 			ret = -EFAULT;
 		} else if ( strnlen(unlink_arg.name,ACH_CHAN_NAME_MAX)

--- a/src/klinux/ach_klinux.c
+++ b/src/klinux/ach_klinux.c
@@ -49,6 +49,7 @@
 #include <linux/kernel.h>	/* KERN_INFO macros */
 #include <linux/module.h>	/* required for all kernel modules */
 #include <linux/moduleparam.h>	/* module_param() and MODULE_PARM_DESC() */
+#include <linux/version.h>
 
 #include <linux/fs.h>		/* struct file_operations, struct file */
 #include <linux/miscdevice.h>	/* struct miscdevice and misc_[de]register() */
@@ -1006,7 +1007,13 @@ static struct miscdevice ach_misc_device = {
 	.mode = DEV_CLASS_MODE
 };
 
+
+// Function signiture update after 6.1.85
+#if LINUX_VERSION_CODE > KERNEL_VERSION(6,1,85)
 static char *ach_devnode(const struct device *dev, umode_t *mode)
+#else
+static char *ach_devnode(struct device *dev, umode_t *mode)
+#endif
 {
 	if (!mode)
 		return NULL;

--- a/src/klinux/ach_klinux.c
+++ b/src/klinux/ach_klinux.c
@@ -562,7 +562,6 @@ static long ach_ch_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 				ret = 0;
 			break;
 		}
-
 	case ACH_CH_GET_STATUS:{
 			KDEBUG("ach: Got cmd ACH_CH_GET_STATUS\n");
 			if (rt_mutex_lock_interruptible(&ch_file->shm->sync.mutex)) {
@@ -610,6 +609,7 @@ static long ach_ch_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 				}
 			}
 			rt_mutex_unlock(&ch_file->shm->sync.mutex);
+			break;
 		}
 	case ACH_CH_FLUSH:
 		KDEBUG("ach: Got cmd ACH_CH_FLUSH\n");

--- a/src/klinux/ach_klinux.c
+++ b/src/klinux/ach_klinux.c
@@ -1008,10 +1008,12 @@ static struct file_operations ach_ctrl_fops = {
 	.llseek = NULL,
 };
 
+#define DEV_CLASS_MODE ((umode_t)(S_IRUGO|S_IWUGO))
 static struct miscdevice ach_misc_device = {
 	.minor = MISC_DYNAMIC_MINOR,
 	.name = "achctrl",
-	.fops = &ach_ctrl_fops
+	.fops = &ach_ctrl_fops,
+	.mode = DEV_CLASS_MODE
 };
 
 static char *ach_devnode(const struct device *dev, umode_t *mode)

--- a/src/klinux/ach_klinux.c
+++ b/src/klinux/ach_klinux.c
@@ -544,6 +544,7 @@ static long ach_ch_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 	switch (cmd) {
 
 	case ACH_CH_SET_MODE: {
+		KDEBUG("ach: Got ACH_CH_SET_MODE\n");
 		struct achk_opt opt;
 		if (copy_from_user(&opt, (void*)arg, sizeof(opt)) ) {
                        ret = -EFAULT;
@@ -622,6 +623,7 @@ static long ach_ch_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 			break;
 		}
 	case ACH_CH_GET_OPTIONS: {
+		KDEBUG("ach: Got ACH_CH_GET_OPTIONS\n");
 		struct ach_ch_options retval;
 		retval.mode = ch_file->mode;
 		retval.clock = ch_file->shm->clock;
@@ -888,6 +890,7 @@ ctrl_create (struct ach_ctrl_create_ch *arg )
 static long ach_ctrl_ioctl(struct file *file, unsigned int cmd,
 			   unsigned long arg)
 {
+	KDEBUG("ach: in ach_ctrl_ioctl");
 	/* TODO: Validate argument */
 	int ret = 0;
 
@@ -923,6 +926,7 @@ static long ach_ctrl_ioctl(struct file *file, unsigned int cmd,
 			struct ach_ch_device *dev;
 			dev = ach_ch_device_find(unlink_arg.name);
 			if (!dev) {
+				printk( KERN_INFO "ach: Couldn't find channel %s\n", unlink_arg.name);
 				ret = -ENOENT;
 				goto out_unlock;
 			}
@@ -943,7 +947,6 @@ static long ach_ctrl_ioctl(struct file *file, unsigned int cmd,
 		ret = -ENOSYS;
 		break;
 	}
-
  out_unlock:
 	rt_mutex_unlock(&ctrl_data.lock);
 	return ret;

--- a/src/klinux/ach_klinux.c
+++ b/src/klinux/ach_klinux.c
@@ -1026,6 +1026,19 @@ static struct miscdevice ach_misc_device = {
 	.fops = &ach_ctrl_fops
 };
 
+static char *ach_devnode(const struct device *dev, umode_t *mode)
+{
+	if (!mode)
+		return NULL;
+	*mode=DEV_CLASS_MODE;
+	return NULL;
+}
+
+struct class ach_class = {
+	.name = ACH_CH_SUBSYSTEM,
+	.devnode = ach_devnode
+};
+
 /**********************************************************************************
  * MODULE INIT
  **********************************************************************************/
@@ -1054,11 +1067,12 @@ static int __init ach_init(void)
 	/* We'll use own major number as we want to control the minor numbers ourself */
 	{
 		dev_t dev_num;
+		ctrl_data.ach_ch_class = &ach_class;
+		int err = class_register(&ach_class);
 
-		ctrl_data.ach_ch_class = class_create(THIS_MODULE, ACH_CH_SUBSYSTEM);
-		if (IS_ERR(ctrl_data.ach_ch_class)) {
-			ret = PTR_ERR(ctrl_data.ach_ch_class);
-			printk(KERN_ERR "ach: Failed to create class\n");
+		if (err < 0) {
+			ret = ACH_FAILED_SYSCALL;
+			printk(KERN_ERR "ach: Failed to create class(%d)\n", err);
 			goto out_deregister;
 		}
 

--- a/src/libach.c
+++ b/src/libach.c
@@ -357,13 +357,13 @@ ach_unlink( const char *name )
     if( ACH_OK != r_name ) return r_name;
 
     r_s = libach_vtab_user.unlink(name);
-    if( !ach_status_match(r_s, ACH_MASK_OK | ACH_MASK_ENOENT) )
+    // If we found the channel in kernel space, quit early
+    if( !ach_status_match(r_s, ACH_MASK_ENOENT) )
         return r_s;
 
     r_k = libach_vtab_klinux.unlink(name);
     if( !ach_status_match(r_k, ACH_MASK_OK | ACH_MASK_ENOENT | ACH_MASK_EACCES) )
         return r_k;
-
     if( ach_status_match(ACH_OK, ach_status_mask(r_s) | ach_status_mask(r_k)) ) {
         /* something was unlinked */
         return ACH_OK;

--- a/src/libach_posix.c
+++ b/src/libach_posix.c
@@ -171,7 +171,8 @@ chan_lock( ach_channel_t *chan ) {
 }
 
 static enum ach_status
-rdlock( ach_channel_t *chan, int wait, const struct timespec *abstime ) {
+rdlock( ach_channel_t *chan, int wait, const void *abstime_ ) {
+    const struct timespec* abstime = (struct timepec*) abstime_;
 
     ach_header_t *shm = chan->shm;
     {


### PR DESCRIPTION
Updated the `ach` kernel for use with modern kernels. The changes broadly follow:
- Updated `timespec` to be `timespec64` as `timespec` no longer exists in the kernel.
- Used the new `class_create` format to ensure that the device channels are read/writable by the user
- Minor bugfixes so all the `make check` tests pass